### PR TITLE
Bewertete Version

### DIFF
--- a/Desktop/ModSim/ModSim WS1718 Uebung 03.ipynb
+++ b/Desktop/ModSim/ModSim WS1718 Uebung 03.ipynb
@@ -164,7 +164,7 @@
    },
    "outputs": [],
    "source": [
-    "Der Vergleich ist Falsch weil vermutlich eine der Zahlen nicht genau dargestellt werden kann."
+    "Der Vergleich ist Falsch weil vermutlich eine der Zahlen nicht genau dargestellt werden kann.#"
    ]
   }
  ],


### PR DESCRIPTION
Af.3 Warum kann einer der Zahl nicht genau dargestellt werden (aber die andere schon)? Keyword: binär (-5)