### PR TITLE
Update ModSim WS1718 Uebung 03.ipynb

### DIFF
--- a/Desktop/ModSim/ModSim WS1718 Uebung 03.ipynb
+++ b/Desktop/ModSim/ModSim WS1718 Uebung 03.ipynb
@@ -164,7 +164,7 @@
    },
    "outputs": [],
    "source": [
-    "Der Vergleich ist Falsch weil vermutlich eine der Zahlen nicht genau dargestellt werden kann."
+    "Der Vergleich ist Falsch weil vermutlich eine der Zahlen nicht genau dargestellt werden kann. #"
    ]
   }
  ],


### PR DESCRIPTION
Af3. Warum ist eine der Zahlen nicht genau dargestellt werden kann? (-5)